### PR TITLE
enable incremental test

### DIFF
--- a/test/rockset.dbtspec
+++ b/test/rockset.dbtspec
@@ -3,6 +3,17 @@ target:
   api_key: <enter_api_key_here>
   workspace: "dbt_test_{{ var('_dbt_random_suffix') }}"
 projects:
+  - overrides: incremental
+    paths:
+      models/incremental.sql:
+        materialized: incremental
+        # Cast as int required for numeric ordering of id field
+        body: |
+            select * from {{ source('raw', 'seed') }}
+            {% if is_incremental() %}
+            where CAST(id as int) > (select max(CAST(id as int)) from {{ this }})
+            {% endif %}
+
   - name: base
     paths:
       data/base.csv: files.seeds.base
@@ -159,8 +170,47 @@ sequences:
       - type: catalog
         exists: True
 
-  # This test fails with row count differences of some kind. May be due to the _id field, which is expected
-  # test_dbt_incremental: incremental
+  test_dbt_incremental:
+    project: incremental
+    sequence:
+      - type: dbt
+        cmd: seed
+      - type: run_results
+        length: fact.seed.length
+      - type: dbt
+        cmd: run
+        vars:
+          seed_name: base
+      - type: relation_rows
+        name: base
+        length: fact.base.rowcount
+      - type: run_results
+        length: fact.run.length
+      - type: relations_equal
+        relations:
+          - base
+          - incremental
+      - type: dbt
+        cmd: run
+        vars:
+          seed_name: added
+      - type: relation_rows
+        name: added
+        length: fact.added.rowcount
+      - type: run_results
+        length: fact.run.length
+      - type: relations_equal
+        relations:
+          - added
+          - incremental
+      - type: dbt
+        cmd: docs generate
+      - type: catalog
+        exists: True
+        nodes:
+          length: fact.catalog.nodes.length
+        # No checks against source doc generation
+
 
   # This test seeds a collection, then seeds it two more times and ensures that docs are incrementally added
   # each time. Then, it seeds in full refresh mode and ensures that docs are back to 10


### PR DESCRIPTION
Enables an incremental test. Overrides the default incremental.sql to cast the id column as an int for comparison purposes. Also inlines most of the default incremental test spec, just drops the assertion for sources within the catalog file.