### PR TITLE
Use new get query endpoint response

### DIFF
--- a/dbt/adapters/rockset/impl.py
+++ b/dbt/adapters/rockset/impl.py
@@ -554,7 +554,8 @@ class RocksetAdapter(BaseAdapter):
         endpoint = f'/v1/orgs/self/queries/{query_id}'
         while True:
             query_resp = self._send_rs_request('GET', endpoint)
-            last_offset = json.loads(query_resp.text)['data']['last_offset']
+            last_offset = json.loads(query_resp.text)['data']['last_offset'] if 'data' in json.loads(
+                query_resp.text) else json.loads(query_resp.text)['last_offset']
             if last_offset is not None:
                 return last_offset
             else:

--- a/dbt/adapters/rockset/impl.py
+++ b/dbt/adapters/rockset/impl.py
@@ -554,7 +554,7 @@ class RocksetAdapter(BaseAdapter):
         endpoint = f'/v1/orgs/self/queries/{query_id}'
         while True:
             query_resp = self._send_rs_request('GET', endpoint)
-            last_offset = json.loads(query_resp.text)['last_offset']
+            last_offset = json.loads(query_resp.text)['data']['last_offset']
             if last_offset is not None:
                 return last_offset
             else:


### PR DESCRIPTION
The get query endpoint was updated to have the last offset field in a different place. Update the dbt adapter to use the get query endpoint in the new way.