### PR TITLE
Adjust execute() signature to BaseConnection::execute()

### DIFF
--- a/dbt/adapters/rockset/connections.py
+++ b/dbt/adapters/rockset/connections.py
@@ -110,7 +110,7 @@ class RocksetConnectionManager(BaseConnectionManager):
 
     # auto_begin is ignored in Rockset, and only included for consistency
     def execute(
-        self, sql: str, auto_begin: bool = False, fetch: bool = False
+        self, sql: str, auto_begin: bool = False, fetch: bool = False, limit: Optional[int] = None
     ) -> Tuple[Union[AdapterResponse, str], agate.Table]:
         sql = self._add_query_comment(sql)
         cursor = self.get_thread_connection().handle.cursor()


### PR DESCRIPTION
I already created a ticket via rockset UI, this PR might fix this.

However, I am unsure, if the limits needs to be respected.

During the execution of `dbt run` with a simple model (e.g. select one col from a table), I receive the following error.

```
RocksetConnectionManager.execute() got an unexpected keyword argument 'limit'
```

Problem:
The Baseclass (BaseConnectionManager) signature differs from the current implementation (https://github.com/dbt-labs/dbt-adapters/blob/main/dbt/adapters/base/connections.py#L398) 

Might be related to https://github.com/rockset/dbt-rockset/issues/30